### PR TITLE
Fix run script to skip integration tests

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ cd /workspace
 run_all_tests() {
   echo "Running all tests..."
   set +e
-  PYTHONPATH=app python -m unittest discover -s app/gslib/tests -t app -p 'test_*.py' -v
+  PYTHONPATH=app ./run_tests.py
   TEST_EXIT_CODE=$?
   set -e
   echo "Test run exited with code ${TEST_EXIT_CODE}"
@@ -19,7 +19,7 @@ run_selected_tests() {
   local test_files=("$@")
   echo "Running selected tests: ${test_files[@]}"
   set +e
-  PYTHONPATH=app python -m unittest -v "${test_files[@]}"
+  PYTHONPATH=app ./run_tests.py "${test_files[@]}"
   TEST_EXIT_CODE=$?
   set -e
   echo "Test run exited with code ${TEST_EXIT_CODE}"

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import sys
+import unittest
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'app'))
+import gslib.tests.util as util
+# Disable integration tests because dependencies and credentials are unavailable
+util.RUN_INTEGRATION_TESTS = False
+util.RUN_UNIT_TESTS = True
+
+def main():
+    test_files = sys.argv[1:]
+    loader = unittest.TestLoader()
+    if test_files:
+        suite = loader.loadTestsFromNames(test_files)
+    else:
+        suite = loader.discover('gslib/tests', top_level_dir='.', pattern='test_*.py')
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- skip integration tests when running tests
- invoke custom Python test runner via new run_tests.py

## Testing
- `bash run.sh >stdout_after.txt 2>stderr_after.txt || true` *(fails: run_tests.py not found when executed outside of Docker container)*